### PR TITLE
A little insurance against bad formatting of error messages

### DIFF
--- a/app/assets/stylesheets/ctl_base_ui/notices.scss
+++ b/app/assets/stylesheets/ctl_base_ui/notices.scss
@@ -39,3 +39,14 @@
   color: $white;
   background-color: $dark_red;
 }
+
+div[class*='notice-'] {
+  h1, h2 {
+    font-size: 100%;
+    color: white;
+    font-weight: bold;
+    border-bottom: 0;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+}


### PR DESCRIPTION
CYA. I wasn't able to repro the issue of some error messages being dumped into the .notice-container as an h1, but here is some insurance in case they are.

![image](https://cloud.githubusercontent.com/assets/775634/7944444/3e4571d6-0930-11e5-9172-bba6cafc4c53.png)
